### PR TITLE
Move example from noinst_PROGRAMS to check_PROGRAMS

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ AM_CXXFLAGS = \
 	$(HUNSPELL_CFLAGS) \
 	$(DEBUG_CXXFLAGS)
 
-noinst_PROGRAMS = example
+check_PROGRAMS = example
 example_SOURCES = example.cxx
 example_LDADD = \
 	libmythes-@MYTHES_MAJOR_VERSION@.@MYTHES_MINOR_VERSION@.la \


### PR DESCRIPTION
`example` should be part of testing and not part of building the main library. With this change, it will be built when running `make check` but not when running `make all`.