### PR TITLE
Mythes::lookup: Prevent potential overflow

### DIFF
--- a/mythes.cxx
+++ b/mythes.cxx
@@ -146,10 +146,14 @@ int MyThes::Lookup(const char * pText, int len, mentry** pme)
     // handle the case of missing file or file related errors
     if (! pdfile) return 0;
 
-    long offset = 0;
+    // check we can allocate enough memory for the string
+    std::vector<char> buffer;
+    if (len < 1 || len > buffer.max_size() - 1) {
+        return 0;
+    }
 
     /* copy search word and make sure null terminated */
-    std::vector<char> buffer(len+1);
+    buffer.resize(len+1);
     char * wrd = &buffer[0];
     memcpy(wrd,pText,len);
   
@@ -158,7 +162,7 @@ int MyThes::Lookup(const char * pText, int len, mentry** pme)
     if (idx < 0) return 0;
 
     // now seek to the offset
-    offset = (long) offst[idx];
+    long offset = (long) offst[idx];
     int rc = fseek(pdfile,offset,SEEK_SET);
     if (rc) {
        return 0;


### PR DESCRIPTION
The size of the string could exceed the maximum size of a std::vector. Detect the case and prevent an overflow.

It was detected by the compiler.

```
In function « void* memcpy(void*, const void*, size_t) »,
    inlined from « int MyThes::Lookup(const char*, int, mentry**) » at mythes.cxx:159:11:
/usr/include/bits/string_fortified.h:29:33: erreur: « void* __builtin_memcpy(void*, const void*, long unsigned int) » la limite spécifiée 18446744073709551615 excède la taille maximale 9223372036854775807 de l'objet [-Werror=stringop-overflow=]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus : tous les avertissements sont traités comme des erreurs
make[3]: *** [Makefile:598: mythes.lo] Error 1
```

As configured in libreoffice on my system:
```
./configure --disable-shared --with-pic --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu build_alias=x86_64-pc-linux-gnu host_alias=x86_64-pc-linux-gnu 'CC=gcc ' 'LDFLAGS=  ' 'LIBS= ' 'CXX=g++ ' 'CXXFLAGS=  -O2 -mtune=generic -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=2 -ggdb2' PKG_CONFIG=/usr/bin/pkg-config PKG_CONFIG_PATH=/lib:/usr/local/lib/pkgconfig/ 'HUNSPELL_CFLAGS=   -I/home/meven/code/libreoffice/core/workdir/UnpackedTarball/hunspell/src/hunspell' 'HUNSPELL_LIBS=   -L/home/meven/code/libreoffice/core/workdir/UnpackedTarball/hunspell/src/hunspell/.libs -lhunspell-1.7'
```